### PR TITLE
WIP: project specific actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.qualixium</groupId>
     <artifactId>executor</artifactId>
-    <version>1.3</version>
+    <version>1.3.1</version>
     <packaging>nbm</packaging>
         <description>
         <![CDATA[

--- a/src/main/java/com/qualixium/executor/ToolbarPanel.form
+++ b/src/main/java/com/qualixium/executor/ToolbarPanel.form
@@ -19,7 +19,7 @@
           <Group type="102" attributes="0">
               <Component id="btnCommandConfig" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="cbxCommands" min="-2" max="-2" attributes="0"/>
+              <Component id="cbxCommands" pref="192" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>


### PR DESCRIPTION
Hi,
I like your plugin and I added the possibility to have project specific commands, which are read on the fly from a subdirectoy `nbproject/executor` whenever you open the dropdown. Every file in this folder is treated as executable and added to the menu with the filename as name.

This way I can have commands which are appropriate for the currently editing project only.

This PR is a WIP because I just hacked it into your code within 10 minutes. If I find some time (which may take very long) I will make it a bit more clean and also stop the UI from freezing so long, but feel free to steal my idea and implement it in your own way if you want.